### PR TITLE
Feature/recover wallet

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -214,7 +214,7 @@
   name = "golang.org/x/crypto"
   packages = ["ripemd160"]
   pruneopts = "UT"
-  revision = "a1f597ede03a7bef967a422b5b3a5bd08805a01e"
+  revision = "b7391e95e576cacdcdd422573063bc057239113d"
 
 [[projects]]
   branch = "master"
@@ -222,7 +222,7 @@
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "6c81ef8f67ca3f42fc9cd71dfbd5f35b0c4b5771"
+  revision = "f49334f85ddcf0f08d7fb6dd7363e9e6d6b777eb"
 
 [[projects]]
   digest = "1:a5000fcb87d763e1d410111d32f3e1d07a6f7913f7efdf68070636c407da54d1"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ export BITCOIN_NET
 run_bitcoind:
 	./scripts/run_bitcoind.sh
 
+reindex_bitciond:
+	./scripts/run_bitcoind.sh --reindex
+
 stop_bitcoind:
 	./scripts/stop_bitcoind.sh
 

--- a/internal/mocks/walletmock/Wallet.go
+++ b/internal/mocks/walletmock/Wallet.go
@@ -30,6 +30,20 @@ func (_m *Wallet) Close() error {
 	return r0
 }
 
+// ImportAddress provides a mock function with given fields: _a0
+func (_m *Wallet) ImportAddress(_a0 btcutil.Address) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(btcutil.Address) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ListUnspent provides a mock function with given fields:
 func (_m *Wallet) ListUnspent() ([]btcjson.ListUnspentResult, error) {
 	ret := _m.Called()

--- a/internal/wallet/address.go
+++ b/internal/wallet/address.go
@@ -30,14 +30,16 @@ func (w *Wallet) NewAddress() (btcutil.Address, error) {
 	return maddr.Address(), nil
 }
 
+// ImportAddress imports an address by creating addresses until reaching to it
+// It stops after creating 100 addresses to avoid infinite loop
 func (w *Wallet) ImportAddress(addr btcutil.Address) error {
 	var maddr waddrmgr.ManagedAddress
-	walletdb.View(w.db, func(tx walletdb.ReadTx) (e error) {
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) (e error) {
 		ns := tx.ReadBucket(waddrmgrNamespaceKey)
 		maddr, e = w.manager.Address(ns, addr)
 		return e
 	})
-	if maddr != nil {
+	if err == nil && maddr != nil {
 		return nil
 	}
 
@@ -53,7 +55,7 @@ func (w *Wallet) ImportAddress(addr btcutil.Address) error {
 		}
 	}
 
-	return errors.New("Failed to import address")
+	return errors.New("failed to import address")
 }
 
 // newAddress returns a new ManagedAddress

--- a/pkg/cmd/dlccli/wallets.go
+++ b/pkg/cmd/dlccli/wallets.go
@@ -15,7 +15,7 @@ import (
 	"github.com/p2pderivatives/dlc/pkg/wallet"
 )
 
-// var seed []byte
+var seed string
 var pubpass string
 var privpass string
 var walletName string
@@ -37,12 +37,11 @@ var walletsCreateCmd = func() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			chainParams := loadChainParams(bitcoinConf)
 
-			// TODO: give seed as command line parameter
-			seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
+			seedB, err := hex.DecodeString(seed)
 			errorHandler(err)
 
 			w, err := _wallet.CreateWallet(chainParams,
-				seed, []byte(pubpass), []byte(privpass),
+				seedB, []byte(pubpass), []byte(privpass),
 				walletDir, walletName)
 			errorHandler(err)
 
@@ -56,6 +55,8 @@ var walletsCreateCmd = func() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&seed, "seed", "", "seed of HD wallet")
+	cmd.MarkFlagRequired("seed")
 	cmd.Flags().StringVar(&walletDir, "walletdir", "", "directory path to store wallets")
 	cmd.MarkFlagRequired("walletdir")
 	cmd.Flags().StringVar(&walletName, "walletname", "", "wallet name")

--- a/pkg/cmd/dlccli/wallets.go
+++ b/pkg/cmd/dlccli/wallets.go
@@ -15,11 +15,6 @@ import (
 	"github.com/p2pderivatives/dlc/pkg/wallet"
 )
 
-var seed string
-var pubpass string
-var privpass string
-var walletName string
-
 // walletCmd represents the wallet command
 var walletsCmd = func() *cobra.Command {
 	cmd := &cobra.Command{
@@ -31,6 +26,11 @@ var walletsCmd = func() *cobra.Command {
 }
 
 var walletsCreateCmd = func() *cobra.Command {
+	var seed string
+	var pubpass string
+	var privpass string
+	var walletName string
+
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new wallet",
@@ -92,6 +92,9 @@ var addrsCmd = func() *cobra.Command {
 }
 
 var addrsCreateCmd = func() *cobra.Command {
+	var pubpass string
+	var walletName string
+
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create address",
@@ -114,7 +117,40 @@ var addrsCreateCmd = func() *cobra.Command {
 	return cmd
 }
 
+var addrsImportCmd = func() *cobra.Command {
+	var pubpass string
+	var walletName string
+	var address string
+
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import address with derivation path",
+		Run: func(cmd *cobra.Command, args []string) {
+			w, _ := openWallet(pubpass, walletDir, walletName)
+			net := loadChainParams(bitcoinConf)
+			addr, err := btcutil.DecodeAddress(address, net)
+			errorHandler(err)
+			err = w.ImportAddress(addr)
+			errorHandler(err)
+		},
+	}
+
+	cmd.Flags().StringVar(&walletDir, "walletdir", "", "directory path to store wallets")
+	cmd.MarkFlagRequired("walletdir")
+	cmd.Flags().StringVar(&walletName, "walletname", "", "wallet name")
+	cmd.MarkFlagRequired("walletname")
+	cmd.Flags().StringVar(&pubpass, "pubpass", "", "public passphrase")
+	cmd.MarkFlagRequired("pubpass")
+	cmd.Flags().StringVar(&address, "address", "", "importing address")
+	cmd.MarkFlagRequired("address")
+
+	return cmd
+}
+
 var balanceCmd = func() *cobra.Command {
+	var pubpass string
+	var walletName string
+
 	cmd := &cobra.Command{
 		Use:   "balance",
 		Short: "Check total balance",
@@ -180,6 +216,9 @@ func init() {
 	addrsRootCmd := addrsCmd()
 	subRootCmd.AddCommand(addrsRootCmd)
 
-	// addresse create
+	// address create
 	addrsRootCmd.AddCommand(addrsCreateCmd())
+
+	// address import
+	addrsRootCmd.AddCommand(addrsImportCmd())
 }

--- a/pkg/wallet/interface.go
+++ b/pkg/wallet/interface.go
@@ -17,6 +17,9 @@ type Wallet interface {
 	// NewAddress creates a new address
 	NewAddress() (btcutil.Address, error)
 
+	// ImportAddress imports address
+	ImportAddress(btcutil.Address) error
+
 	// WitnessSignature returns witness signature for a given txin and pubkey
 	WitnessSignature(
 		tx *wire.MsgTx, idx int, amt btcutil.Amount, sc []byte, pub *btcec.PublicKey,

--- a/scripts/run_bitcoind.sh
+++ b/scripts/run_bitcoind.sh
@@ -12,6 +12,11 @@ function getnetworkinfo() {
   echo $?
 }
 
+while [[ "$#" -ne "0" ]];do
+  opts+=( ${1} )
+  shift
+done
+
 if [[ "$(getnetworkinfo)" -ne "0" ]];then
   $bitcoind "${opts[@]}"
 

--- a/scripts/run_bitcoind.sh
+++ b/scripts/run_bitcoind.sh
@@ -12,22 +12,21 @@ function getnetworkinfo() {
   echo $?
 }
 
-function run_bitcoind() {
-  $bitcoind "${opts[@]}"
-  echo $?
-}
-
 if [[ "$(getnetworkinfo)" -ne "0" ]];then
-  if [[ "$(run_bitcoind)" -ne "0" ]];then
-    exit 1
-  fi
+  $bitcoind "${opts[@]}"
 
   # wait until accepting rpc requests
+  cnt=0
   while true;do
     if [[ "$(getnetworkinfo)" -eq "0" ]];then
       break
     fi
+    if [[ "$cnt" -gt "100" ]];then
+      echo "Failed to start bitcoind. see debug.log for more details."
+      exit 1
+    fi
     sleep 0.1
+    cnt=$(($cnt+1))
   done
 else
   echo "Bitcoind is already running"

--- a/test/cmd/create_wallets.sh
+++ b/test/cmd/create_wallets.sh
@@ -1,19 +1,34 @@
 #!/bin/bash
 
 net=${BITCOIN_NET:=regtest}
-dlc_params="--conf ./conf/bitcoin.${net}.conf --walletdir ./wallets/${net}"
-alice_params="--walletname alice --pubpass pub_alice --privpass priv_alice"
-alice_personal_params="--walletname alicep --pubpass pub_alicep --privpass priv_alicep"
-alice_params="--walletname alice --pubpass pub_alice --privpass priv_alice"
-bob_params="--walletname bob --pubpass pub_bob --privpass priv_bob"
-bob_personal_params="--walletname bobp --pubpass pub_bobp --privpass priv_bobp"
+conf="--conf ./conf/bitcoin.${net}.conf"
+dlc_params="${conf} --walletdir ./wallets/${net}"
+alice_params=( --walletname alice --pubpass pub_alice --privpass priv_alice )
+alice_personal_params=( --walletname alicep --pubpass pub_alicep --privpass priv_alicep )
+bob_params=( --walletname bob --pubpass pub_bob --privpass priv_bob )
+bob_personal_params=( --walletname bobp --pubpass pub_bobp --privpass priv_bobp )
 create_wallet="dlccli wallets create"
 
+function create_wallet() {
+  seed=$(dlccli wallets seed $conf)
+  wallet_params="--seed $seed"
+  for i in "$@";
+  do
+    wallet_params="$wallet_params $i"
+  done
+  cmd="$create_wallet $dlc_params $wallet_params"
+  echo $cmd
+  $cmd
+}
+
 echo "Creating Alice's DLC wallet"
-$create_wallet $dlc_params $alice_params
+create_wallet "${alice_params[@]}"
+
 echo "Creating Alice's personal wallet"
-$create_wallet $dlc_params $alice_personal_params
+create_wallet "${alice_personal_params[@]}"
+
 echo "Creating Bob's DLC wallet"
-$create_wallet $dlc_params $bob_params
+create_wallet "${bob_params[@]}"
+
 echo "Creating Bob's personal wallet"
-$create_wallet $dlc_params $bob_personal_params
+create_wallet "${bob_personal_params[@]}"


### PR DESCRIPTION
- Implemented an option to recover DLC wallet for mainnet QA.
   - create wallet using seed and regenerate addresses one by one
      https://github.com/p2pderivatives/dlc/pull/105/files#diff-91bf7b1b051d9ad1fcbd3daf4976a2ddR33
- manually tested on testnet

## Recovery steps

Create wallet

```
dlccli wallets create \                                                                                                                                                                                          
    --conf ./conf/bitcoin.testnet.conf \
    --walletdir ./wallets/testnet \
    --walletname "alice_recover" \
    --privpass "priv_alice" \
    --pubpass "pub_alice" \
    —seed 791729bd1e8dbdc31d0603f9116ab18bd701e02c78094b262ffe73af837a0446
```

Import address to temporal DLC wallet

```
dlccli wallets addresses import \
    --conf ./conf/bitcoin.testnet.conf \
    --walletdir ./wallets/testnet \
    --walletname "alice_recover" \
    --pubpass "pub_alice" \
    --address tb1qwwrtlm034ecmauf5x5ktzjw8zz0v7wufqpmccs
```

Import address to bitcoind

```
# rescan=true by default
bitcoin-cli -conf=bitcoin.testnet.conf -datadir=./bitcoind \
    importaddress tb1qwwrtlm034ecmauf5x5ktzjw8zz0v7wufqpmccs
```

Check balance

```
dlccli wallets balance \
    --conf ./conf/bitcoin.testnet.conf \
    --walletdir ./wallets/testnet \
    --walletname "alice_recover" \
    --pubpass "pub_alice"
```