### PR TITLE
support non-segwit target address

### DIFF
--- a/pkg/dlc/dlc.go
+++ b/pkg/dlc/dlc.go
@@ -8,9 +8,9 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"github.com/p2pderivatives/dlc/pkg/script"
 	"github.com/p2pderivatives/dlc/pkg/wallet"
 	validator "gopkg.in/go-playground/validator.v9"
 )
@@ -108,7 +108,8 @@ func (d *DLC) distTxOut(
 		msg := fmt.Sprintf("missing destination address. %s", p)
 		return nil, errors.New(msg)
 	}
-	sc, err := script.P2WPKHpkScriptFromAddress(addr)
+
+	sc, err := txscript.PayToAddrScript(addr)
 	if err != nil {
 		return nil, err
 	}

--- a/test/cmd/create_dlc.sh
+++ b/test/cmd/create_dlc.sh
@@ -2,7 +2,7 @@
 
 net=${BITCOIN_NET:=regtest}
 conf="bitcoin.${net}.conf"
-conf="--conf ./conf/${conf}"
+conf_param="--conf ./conf/${conf}"
 walletdir="--walletdir ./wallets/${net}"
 create_address="dlccli wallets addresses create"
 alicep_params="--walletname alicep --pubpass pub_alicep"
@@ -10,7 +10,7 @@ bobp_params="--walletname bobp --pubpass pub_bobp"
 
 echo "Getting oracle's pubkey"
 oracle_pubkey_file="opub.json"
-dlccli oracle rpoints $conf \
+dlccli oracle rpoints $conf_param \
     --oraclename "olivia" \
     --rpoints 4 \
     --fixingtime "2019-04-30T12:00:00Z" \
@@ -18,18 +18,20 @@ dlccli oracle rpoints $conf \
 echo -e ""
 
 echo "Creating addresses"
-addr1=`$create_address $conf $walletdir $alicep_params`
-addr2=`$create_address $conf $walletdir $bobp_params`
+addr1=`bitcoin-cli -datadir=./bitcoind -conf=${conf} getnewaddress` # p2sh
+addr2=`bitcoin-cli -datadir=./bitcoind -conf=${conf} getnewaddress` # p2sh
+# addr1=$create_address $conf $walletdir $alicep_params`
+# addr2=`$create_address $conf $walletdir $bobp_params`
 echo "address1: $addr1"
 echo "address2: $addr2"
-chaddr1=`$create_address $conf $walletdir $alicep_params`
-chaddr2=`$create_address $conf $walletdir $bobp_params`
+chaddr1=`$create_address $conf_param $walletdir $alicep_params`
+chaddr2=`$create_address $conf_param $walletdir $bobp_params`
 echo "change address1: $chaddr1"
 echo "change address2: $chaddr2"
 echo -e ""
 
 echo "Creating DLC"
-cmd="dlccli contracts create $conf $walletdir \
+cmd="dlccli contracts create $conf_param $walletdir \
         --oracle_pubkey $oracle_pubkey_file \
         --fixingtime 2019-04-30T12:00:00Z \
         --fund1 2000 \


### PR DESCRIPTION
Currently, p2wpkh is only allowed for target address. 

changed the implementation to use [txscript.PayToAddressScript](https://github.com/btcsuite/btcd/blob/master/txscript/standard.go#L420) to support 5 standard addresses.

tested on regtest only