### PR TITLE
fix-utxo-duplicate

### DIFF
--- a/pkg/dlc/fundtx.go
+++ b/pkg/dlc/fundtx.go
@@ -159,8 +159,8 @@ func (b *Builder) PrepareFundTx() error {
 
 	// set utxos to DLC
 	_utxos := []*Utxo{}
-	for _, utxo := range utxos {
-		_utxos = append(_utxos, &utxo)
+	for i, _ := range utxos {
+		_utxos = append(_utxos, &utxos[i])
 	}
 	b.Contract.Utxos[b.party] = _utxos
 
@@ -188,8 +188,8 @@ func (b *Builder) AcceptUtxos(utxos []Utxo) error {
 	// TODO: validate if total amount is enough
 
 	_utxos := []*Utxo{}
-	for _, utxo := range utxos {
-		_utxos = append(_utxos, &utxo)
+	for i, _ := range utxos {
+		_utxos = append(_utxos, &utxos[i])
 	}
 	b.Contract.Utxos[cp] = _utxos
 


### PR DESCRIPTION
There is a small bug when creating a fund transaction using more than one UTXO where the set of UTXOs of the transaction will be composed of a duplication of a the last selected UTXO due to some pointer manipulation error. This PR fixes it.