### PR TITLE
Add createwithpremium command

### DIFF
--- a/conf/bitcoin.regtest.conf
+++ b/conf/bitcoin.regtest.conf
@@ -5,3 +5,4 @@ txindex=1
 keypool=10
 daemon=1
 listen=1
+deprecatedrpc=generate

--- a/internal/dlcmgr/manager_test.go
+++ b/internal/dlcmgr/manager_test.go
@@ -117,7 +117,7 @@ func testConditions() *dlc.Conditions {
 	deals := newDeals()
 
 	conds, _ := dlc.NewConditions(
-		net, ftime, famt1, famt2, feerate, feerate, refundlc, deals)
+		net, ftime, famt1, famt2, feerate, feerate, refundlc, deals, nil)
 
 	return conds
 }

--- a/pkg/cmd/dlccli/contracts.go
+++ b/pkg/cmd/dlccli/contracts.go
@@ -21,6 +21,9 @@ func init() {
 	// create contract
 	contractsCmd.AddCommand(initCreateContractCmd())
 
+	// create contract with premium command
+	contractsCmd.AddCommand(initCreateContractWithPremiumCmd())
+
 	// subcommand deals
 	contractsCmd.AddCommand(dealsCmd)
 

--- a/pkg/dlc/dlc.go
+++ b/pkg/dlc/dlc.go
@@ -57,6 +57,13 @@ type Conditions struct {
 	RedeemFeerate  btcutil.Amount                `validate:"required,gt=0"` // redeem fee rate (satoshi per byte)
 	RefundLockTime uint32                        `validate:"required,gt=0"` // refund locktime (block height)
 	Deals          []*Deal                       `validate:"required,gt=0,dive,required"`
+	PremiumInfo    *PremiumInfo
+}
+
+type PremiumInfo struct {
+	PremiumDestAddress btcutil.Address			`validate:"required"`
+	PremiumAmount 	   btcutil.Amount			`validate:"required,gt=0"`
+	PayingParty        Contractor				`validate:"oneof= 0 1"`
 }
 
 // NewConditions creates a new DLC conditions
@@ -67,6 +74,7 @@ func NewConditions(
 	ffeerate, rfeerate btcutil.Amount, // fund feerate and redeem feerate
 	refundLockTime uint32, // refund locktime
 	deals []*Deal,
+	info *PremiumInfo,
 ) (*Conditions, error) {
 	famts := make(map[Contractor]btcutil.Amount)
 	famts[FirstParty] = famt1
@@ -80,12 +88,25 @@ func NewConditions(
 		RedeemFeerate:  rfeerate,
 		RefundLockTime: refundLockTime,
 		Deals:          deals,
+		PremiumInfo:   info,
 	}
 
 	// validate structure
 	err := validator.New().Struct(conds)
 
 	return conds, err
+}
+
+func NewPremiumInfo(premiumAddress btcutil.Address, premiumAmount btcutil.Amount, payingParty Contractor) (*PremiumInfo, error) {
+	premiumInfo := &PremiumInfo{
+		PremiumDestAddress: premiumAddress,
+		PremiumAmount:      premiumAmount,
+		PayingParty:        payingParty,
+	}
+
+	err := validator.New().Struct(premiumInfo)
+
+	return premiumInfo, err
 }
 
 // ContractID returns contract ID

--- a/pkg/dlc/dlc_test.go
+++ b/pkg/dlc/dlc_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testAddress = "bcrt1q8cjx85nnuqd92mq3xnfrqc4xxljhm5sjax55rk"
+
 func TestCondions(t *testing.T) {
 	assert := assert.New(t)
 
@@ -21,31 +23,92 @@ func TestCondions(t *testing.T) {
 
 	var err error
 	_, err = NewConditions(
-		net, ftime, famt1, famt2, frate, rrate, lc, deals)
+		net, ftime, famt1, famt2, frate, rrate, lc, deals, nil)
 	assert.NoError(err)
 
 	_, err = NewConditions(
-		net, time.Now(), famt1, famt2, frate, rrate, lc, deals)
+		net, time.Now(), famt1, famt2, frate, rrate, lc, deals, nil)
 	assert.Error(err)
 
 	_, err = NewConditions(
-		net, ftime, 0, famt2, frate, rrate, lc, deals)
+		net, ftime, 0, famt2, frate, rrate, lc, deals, nil)
 	assert.Error(err)
 
 	_, err = NewConditions(
-		net, ftime, famt1, 0, frate, rrate, lc, deals)
+		net, ftime, famt1, 0, frate, rrate, lc, deals, nil)
 	assert.Error(err)
 
 	_, err = NewConditions(
-		net, ftime, famt1, famt2, 0, rrate, lc, deals)
+		net, ftime, famt1, famt2, 0, rrate, lc, deals, nil)
 	assert.Error(err)
 
 	_, err = NewConditions(
-		net, ftime, famt1, famt2, frate, 0, lc, deals)
+		net, ftime, famt1, famt2, frate, 0, lc, deals, nil)
 	assert.Error(err)
 
 	_, err = NewConditions(
-		net, ftime, famt1, famt2, frate, rrate, lc, []*Deal{})
+		net, ftime, famt1, famt2, frate, rrate, lc, []*Deal{}, nil)
+	assert.Error(err)
+}
+
+func TestNewPremiumInfo_CorrectParameters_NoError(t *testing.T) {
+	// Arrange
+	assert := assert.New(t)
+	address, err := btcutil.DecodeAddress(testAddress, &chaincfg.RegressionNetParams)
+	assert.NoError(err)
+
+	amount := btcutil.Amount(5000)
+	party := Contractor(0)
+
+	// Act
+	_, err = NewPremiumInfo(address, amount, party)
+
+	// Assert
+	assert.NoError(err)
+}
+
+func TestNewPremiumInfo_IncorrectAmount_Error(t *testing.T) {
+
+	// Arrange
+	assert := assert.New(t)
+	address, err := btcutil.DecodeAddress(testAddress, &chaincfg.RegressionNetParams)
+	assert.NoError(err)
+	amount := btcutil.Amount(0)
+	party := Contractor(0)
+
+	// Act
+	_, err = NewPremiumInfo(address, amount, party)
+
+	// Assert
+	assert.Error(err)
+}
+
+func TestNewPremiumInfo_IncorrectParty_Error(t *testing.T) {
+
+	// Arrange
+	assert := assert.New(t)
+	address, err := btcutil.DecodeAddress(testAddress, &chaincfg.RegressionNetParams)
+	assert.NoError(err)
+	amount := btcutil.Amount(5000)
+	party := Contractor(3)
+
+	// Act
+	_, err = NewPremiumInfo(address, amount, party)
+
+	// Assert
+	assert.Error(err)
+}
+
+func TestNewPremiumInfo_NilAddress_Error(t *testing.T) {
+	// Arrange
+	assert := assert.New(t)
+	amount := btcutil.Amount(5000)
+	party := Contractor(0)
+
+	// Act
+	_, err := NewPremiumInfo(nil, amount, party)
+
+	// Assert
 	assert.Error(err)
 }
 

--- a/pkg/dlc/fundtx_test.go
+++ b/pkg/dlc/fundtx_test.go
@@ -71,12 +71,12 @@ func TestPrepareFundTxNoChange(t *testing.T) {
 	assert.NotNil(utxos, "utxos")
 }
 
-func TestFundTx(t *testing.T) {
+func testFundTx(t *testing.T, conditions func() *Conditions, expectedOutLen int) {
 	assert := assert.New(t)
 
 	// init builders
-	b1 := setupBuilder(FirstParty, setupTestWallet, newTestConditions)
-	b2 := setupBuilder(SecondParty, setupTestWallet, newTestConditions)
+	b1 := setupBuilder(FirstParty, setupTestWallet, conditions)
+	b2 := setupBuilder(SecondParty, setupTestWallet, conditions)
 
 	// prep
 	stepPrepare(b1)
@@ -92,7 +92,17 @@ func TestFundTx(t *testing.T) {
 	tx, err := b1.Contract.FundTx()
 	assert.Nil(err)
 	assert.Len(tx.TxIn, 2)  // funds from both parties
-	assert.Len(tx.TxOut, 3) // 1 for reddemtx and 2 for changes
+	assert.Len(tx.TxOut, expectedOutLen)
+}
+
+func TestFundTxNoPremium(t *testing.T) {
+	expectedOutLen := 3  // 1 for redeemtx and 2 for changes
+	testFundTx(t, newTestConditions, expectedOutLen)
+}
+
+func TestFundTxWithPremium(t *testing.T) {
+	expectedOutLen := 4  // 1 for redeemtx, 2 for changes and one for premium
+	testFundTx(t, newTestConditionsWithPremium, expectedOutLen)
 }
 
 func TestRedeemFundTx(t *testing.T) {

--- a/pkg/dlc/test_util.go
+++ b/pkg/dlc/test_util.go
@@ -97,8 +97,25 @@ func mockSelectUnspent(
 
 func newTestConditions() *Conditions {
 	net := &chaincfg.RegressionNetParams
-	conds, _ := NewConditions(net, time.Now(), 1, 1, 1, 1, 1, []*Deal{})
+	conds, _ := NewConditions(net, time.Now(), 1, 1, 1, 1, 1, []*Deal{}, nil)
 	return conds
+}
+
+func newTestConditionsWithPremium() *Conditions {
+	info := newTestPremiumInfo()
+	net := &chaincfg.RegressionNetParams
+	conds, _ := NewConditions(net, time.Now(), 1, 1, 1, 1, 1, []*Deal{}, info)
+	return conds
+}
+
+func newTestPremiumInfo() *PremiumInfo {
+	address, _ := btcutil.DecodeAddress("bcrt1q8cjx85nnuqd92mq3xnfrqc4xxljhm5sjax55rk", &chaincfg.RegressionNetParams)
+	amount := btcutil.Amount(5000)
+	party := Contractor(0)
+
+	info, _ := NewPremiumInfo(address, amount, party)
+
+	return info
 }
 
 func setupBuilder(

--- a/test/integration/dlc_test.go
+++ b/test/integration/dlc_test.go
@@ -169,7 +169,7 @@ func contractorsBetOnLottery(
 	deals := randomDealsForAllDigitPatterns(nDigit, int(famta+famtb))
 	net := &chaincfg.RegressionNetParams
 	conds, err := dlc.NewConditions(
-		net, fixingTime, famta, famtb, 1, 1, refundUnlockAt, deals)
+		net, fixingTime, famta, famtb, 1, 1, refundUnlockAt, deals, nil)
 	assert.NoError(t, err)
 
 	c1.createDLCBuilder(conds, dlc.FirstParty)

--- a/test/integration/oracle_test.go
+++ b/test/integration/oracle_test.go
@@ -52,7 +52,7 @@ func contractorBetOnWeatherAndTemperature(t *testing.T, c *Contractor) time.Time
 	deals := []*dlc.Deal{deal1, deal2, deal3, deal4}
 	fixingTime := time.Now().AddDate(0, 0, 1)
 	net := &chaincfg.RegressionNetParams
-	conds, err := dlc.NewConditions(net, fixingTime, 1, 1, 1, 1, 1, deals)
+	conds, err := dlc.NewConditions(net, fixingTime, 1, 1, 1, 1, 1, deals, nil)
 	assert.NoError(t, err)
 	c.createDLCBuilder(conds, dlc.FirstParty)
 	return fixingTime


### PR DESCRIPTION
This PR adds a `contract createwithpremium` command to enable one of the party to pay a premium to the other in the fund transaction.

The goal was to try to modify the current implementation as little as possible. A couple of tests are also added.

# Usage

The parameters are the same as the `contract create` command, with additional three parameters:

- `premiumdestaddress`: the address to which the premium will be sent,
- `premiumamount`: the amount to be paid as premium (in satoshi),
- `premiumpayingparty`: which party pays the premium (0 or 1).

# Example

```bash
dlccli contracts createwithpremium \
--conf ./bitcoind/bitcoin.regtest.conf \
--oracle_pubkey ./opub.json \
--fixingtime "2019-08-15T05:25:00Z" \
--fund1 500000 \
--fund2 500000 \
--address1 "bcrt1qw7xvwkmvtx3rmepm9fs0khke9a6cdrqj5urq5j" \
--address2 "bcrt1qmsa83c7u8a8u4l37hkvw5lrzhrdsrhmyszwpfk" \
--change_address1 "bcrt1q5mzhm2ar66qnds6te3ug7wywgsq9arz05exs8q" \
--change_address2 "bcrt1qmp9e4kn0d999jes5d5dulu2jspadyrl7dfpazk" \
--fundtx_feerate 50 \
--redeemtx_feerate 40 \
--deals_file ./test/cmd/deal.csv \
--refund_locktime 5000 \
--walletdir ./wallets/regtest/ \
--wallet1 "alice" \
--wallet2 "bob" \
--pubpass1 "pub_alice" \
--pubpass2 "pub_bob" \
--privpass1 "priv_alice" \
--privpass2 "priv_bob" \
--premiumamount 5000 \
--premiumdestaddress "bcrt1qumsh9wnl2jwyajwvcnnlh6th4zzxdnes5988n7" \
--premiumpayingparty 1
```
Output:
```
Contract created

ContractID: 
cd710713d9eb6162977c198bc620213b412a48245f8879da16b46c439a42e41b

FundTx hex:
02000000000102360a74f111b9b9d731068728e190c7fc7d2886226fa7a54b1eb99fa4afcf701e0100000000ffffffff58423b8688c3f5db0e3c896de008dfdf80503102a24cf36d4e2323b08e267fb10000000000ffffffff04589d0f00000000002200203f35a70dcb25fff3ca0aff43b00d49acb78ca832e83b47faaa745e72f50a769f4d9f900000000000160014a6c57daba3d68136c34bcc788f388e44005e8c4fe08b290100000000160014d84b9ada6f694a5966146d1bcff152807ad20ffe8813000000000000160014e6e172ba7f549c4ec9ccc4e7fbe977a88466cf300247304402201d8495bcdadb53831276d0365cf9ecdc2de2c08961bddcdcfda383ed7ee02a1a02205ab995e0c1418c581b42117c113c35b471ab9ecbc7387827a6d890dd8d6f22aa012103a248b6051c36d271aaf0263d651cbcb0f79bf2741307fae6fdce747629bc315c02483045022100dba5c960739da84f70b4e0b5ced8e51881cb625c2482592a864f1f410b955f55022070ce98888cfa26907fda42edaff2c10b9eaf551651d07654ff9ca0a79f345e4501210369cb7d26ae846420d2f57ca3307d6433da6a0b027c3dbf9a7981d25f0e3f13d200000000

RefundTx hex:
020000000001011be4429a436cb416da79885f24482a413b2120c68b197c976261ebd9130771cd0000000000feffffff0220a1070000000000160014778cc75b6c59a23de43b2a60fb5ed92f75868c1220a1070000000000160014dc3a78e3dc3f4fcafe3ebd98ea7c62b8db01df64040047304402207d89cf099426808b7132ef33e1ea132622cee649679cb47a47e3da6d407462f2022020824291dc4f5a5a870347652473321dd3d09c876856b54176470a54dcc62d5201473044022061062c39649848f1e166771d82fb456b2332dd1c528338b21031aa834a4c6c8e0220577d6d4829774be6887d478e371f4b363ad04a90b3529ac196e47af1f6d36ae30147522102c34028762e35fd1ba0dbb542f8ae9c4b953d7e8a14c996c8768a0454b8654efa2103896fbf21729db10f163e2c59691697bc3f1a21fc7240806de4e4ddf45df64eff52ae88130000
```

Decoded transaction (the premium is the last output):

```json
{
  "txid": "cd710713d9eb6162977c198bc620213b412a48245f8879da16b46c439a42e41b",
  "hash": "bc3578c7e1c6e5a7c42e2ad0676c4cff09df258ae22c50c9ed20167e7f8b5f30",
  "version": 2,
  "size": 445,
  "vsize": 283,
  "weight": 1129,
  "locktime": 0,
  "vin": [
    {
      "txid": "1e70cfafa49fb91e4ba5a76f2286287dfcc790e128870631d7b9b911f1740a36",
      "vout": 1,
      "scriptSig": {
        "asm": "",
        "hex": ""
      },
      "txinwitness": [
        "304402201d8495bcdadb53831276d0365cf9ecdc2de2c08961bddcdcfda383ed7ee02a1a02205ab995e0c1418c581b42117c113c35b471ab9ecbc7387827a6d890dd8d6f22aa01",
        "03a248b6051c36d271aaf0263d651cbcb0f79bf2741307fae6fdce747629bc315c"
      ],
      "sequence": 4294967295
    },
    {
      "txid": "b17f268eb023234e6df34ca202315080dfdf08e06d893c0edbf5c388863b4258",
      "vout": 0,
      "scriptSig": {
        "asm": "",
        "hex": ""
      },
      "txinwitness": [
        "3045022100dba5c960739da84f70b4e0b5ced8e51881cb625c2482592a864f1f410b955f55022070ce98888cfa26907fda42edaff2c10b9eaf551651d07654ff9ca0a79f345e4501",
        "0369cb7d26ae846420d2f57ca3307d6433da6a0b027c3dbf9a7981d25f0e3f13d2"
      ],
      "sequence": 4294967295
    }
  ],
  "vout": [
    {
      "value": 0.01023320,
      "n": 0,
      "scriptPubKey": {
        "asm": "0 3f35a70dcb25fff3ca0aff43b00d49acb78ca832e83b47faaa745e72f50a769f",
        "hex": "00203f35a70dcb25fff3ca0aff43b00d49acb78ca832e83b47faaa745e72f50a769f",
        "reqSigs": 1,
        "type": "witness_v0_scripthash",
        "addresses": [
          "bcrt1q8u66wrwtyhll8js2lapmqr2f4jmce2pjaqa50742w3089ag2w60sqfq6yx"
        ]
      }
    },
    {
      "value": 0.09477965,
      "n": 1,
      "scriptPubKey": {
        "asm": "0 a6c57daba3d68136c34bcc788f388e44005e8c4f",
        "hex": "0014a6c57daba3d68136c34bcc788f388e44005e8c4f",
        "reqSigs": 1,
        "type": "witness_v0_keyhash",
        "addresses": [
          "bcrt1q5mzhm2ar66qnds6te3ug7wywgsq9arz05exs8q"
        ]
      }
    },
    {
      "value": 0.19500000,
      "n": 2,
      "scriptPubKey": {
        "asm": "0 d84b9ada6f694a5966146d1bcff152807ad20ffe",
        "hex": "0014d84b9ada6f694a5966146d1bcff152807ad20ffe",
        "reqSigs": 1,
        "type": "witness_v0_keyhash",
        "addresses": [
          "bcrt1qmp9e4kn0d999jes5d5dulu2jspadyrl7dfpazk"
        ]
      }
    },
    {
      "value": 0.00005000,
      "n": 3,
      "scriptPubKey": {
        "asm": "0 e6e172ba7f549c4ec9ccc4e7fbe977a88466cf30",
        "hex": "0014e6e172ba7f549c4ec9ccc4e7fbe977a88466cf30",
        "reqSigs": 1,
        "type": "witness_v0_keyhash",
        "addresses": [
          "bcrt1qumsh9wnl2jwyajwvcnnlh6th4zzxdnes5988n7"
        ]
      }
    }
  ]
}
```